### PR TITLE
Make links open in new tab/window.

### DIFF
--- a/vendor/assets/javascripts/pdf_viewer_rails/pdf.js
+++ b/vendor/assets/javascripts/pdf_viewer_rails/pdf.js
@@ -6472,6 +6472,10 @@ var AnnotationUtils = (function AnnotationUtilsClosure() {
     var link = document.createElement('a');
     link.href = link.title = item.url || '';
 
+    // XXX: Force links to open in a new tab/window. See:
+    // https://gist.github.com/CodingFabian/11178827
+    link.target = '_blank';
+
     container.appendChild(link);
 
     return container;


### PR DESCRIPTION
Fix for: https://www.pivotaltracker.com/n/projects/984568/stories/75350816

When clicking an http link in a PDF, it was failing with a mixed-content use warning. This patch makes it so links will open in a new tab, which besides working around the security problem, is also probably what we want to have happen anyways.